### PR TITLE
Don't modify globals

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,14 @@
-try {
- // optional dependency on polyfill-promise
- global.Promise = global.Promise || require('polyfill-promise')
-} finally {}
+var Promise
+
+if (global.Promise) {
+  Promise = global.Promise
+} else {
+  try {
+    Promise = require('polyfill-promise')
+  } catch (err) {
+    throw new Error('No Promise found, please install `polyfill-promise`')
+  }
+}
 
 function promiseDelay (delay, val) {
   return new Promise(function (resolve) {
@@ -9,7 +16,6 @@ function promiseDelay (delay, val) {
       resolve(val)
     }, delay)
   })
-
 }
 
 module.exports = promiseDelay

--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
   "repository": "git@github.com:jden/node-promise-delay.git",
   "license": "ISC",
   "readmeFilename": "README.md",
-  "optionalDependencies": {
-    "polyfill-promise": "~4.0.1"
-  },
   "devDependencies": {
     "mochi": "0.3.0"
   }


### PR DESCRIPTION
Hi again :)

The problem with adding an `optionalDependency` is that it will still _always_ be installed. The name is a bit misleading but the use case is for when something should be used, but in the case that it errors on installation, it can work without it. A good example of this is the Postgres database driver, which prefers to work with natively compiled drivers, but that can use a javascript-only version if those fails.

Another problem is that you are modifying the global scope, which is an anti-pattern. Modifying global scope can lead to hard to track down bugs and is generally frowned upon.

What do you think about this implementation? If `global.Promise` is available, which it should be for almost all people since 0.10 is beyond end of life, it will simply use the builtin promise. Otherwise it will try to require in `polyfill-promise`, and if it isn't installed, it will fail with a friendly message.

Also, `finally {}` doesn't catch and drop errors, which made your module still fail with `Error: Cannot find module 'polyfill-promise'`.

``` text
> delete global.Promise
true
> require('promise-delay')
Error: Cannot find module 'polyfill-promise'
    at Function.Module._resolveFilename (module.js:339:15)
    at Function.Module._load (module.js:290:25)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at Object.<anonymous> (/private/tmp/hdjaks/node_modules/promise-delay/index.js:3:37)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
> try { throw new Error('test') } finally {}
Error: test
    at repl:1:13
    at REPLServer.defaultEval (repl.js:252:27)
    at bound (domain.js:287:14)
    at REPLServer.runBound [as eval] (domain.js:300:12)
    at REPLServer.<anonymous> (repl.js:417:12)
    at emitOne (events.js:95:20)
    at REPLServer.emit (events.js:182:7)
    at REPLServer.Interface._onLine (readline.js:211:10)
    at REPLServer.Interface._line (readline.js:550:8)
    at REPLServer.Interface._ttyWrite (readline.js:827:14)
```

Lets make this an awesome module :raised_hands: 
